### PR TITLE
Basic mem manager api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# CMake minimum version and project name
-
-cmake_minimum_required(VERSION 3.13)
-project(MLI LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.26)
+project(MLI VERSION 1.0.0 LANGUAGES C CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -47,3 +45,31 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti")
 # Add subdirectories
 add_subdirectory(lib)
 add_subdirectory(src)
+
+# Install include files
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp" PATTERN "*.td" PATTERN "*.inc")
+
+# Install and export the targets
+install(EXPORT MLITargets
+        FILE MLITargets.cmake
+        NAMESPACE MLI::
+        DESTINATION lib/cmake/MLI)
+
+# Generate and install package config files
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/MLIConfigVersion.cmake"
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/MLIConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/MLIConfig.cmake"
+    INSTALL_DESTINATION lib/cmake/MLI)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/MLIConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/MLIConfigVersion.cmake"
+    DESTINATION lib/cmake/MLI)

--- a/cmake/MLIConfig.cmake.in
+++ b/cmake/MLIConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+include("${CMAKE_CURRENT_LIST_DIR}/MLITargets.cmake")
+
+# Import dependencies
+find_package(LLVM REQUIRED CONFIG)
+find_package(MLIR REQUIRED CONFIG)

--- a/include/mlir/Interpreter/Interpreter.h
+++ b/include/mlir/Interpreter/Interpreter.h
@@ -17,6 +17,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Interpreter/InterpreterOpInterface.h"
+#include "mlir/Interpreter/MemoryManager.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
@@ -72,10 +73,12 @@ private:
 
 } // namespace detail
 
+
 class Interpreter {
 public:
   explicit Interpreter(MLIRContext &context,
-                       bool enableStackTraceOnError = false);
+                       bool enableStackTraceOnError = false,
+                       std::unique_ptr<MemoryManager> MemManager = nullptr);
 
   //===--------------------------------------------------------------------===//
   // Dialect interpreter registration
@@ -296,6 +299,8 @@ public:
                            sizeof(T) * data.size());
   }
 
+  // TODO: Change to smart pointer
+  MemoryManager &getMemManager() { return *MemManager; }
 private:
   /// Mapping from SSA names to evaluated value. This represents a value lookup
   /// scope within a region.
@@ -324,6 +329,7 @@ private:
 private:
   Interpreter(const Interpreter &) = delete;
   Interpreter &operator=(const Interpreter &) = delete;
+  std::unique_ptr<MemoryManager> MemManager;
 };
 
 /// Helper class to push and pop a function frame in a C++ scope.

--- a/include/mlir/Interpreter/MemoryManager.h
+++ b/include/mlir/Interpreter/MemoryManager.h
@@ -1,0 +1,124 @@
+#ifndef MLIR_INTERPRETER_MEMORYMANAGER_H
+#define MLIR_INTERPRETER_MEMORYMANAGER_H
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include <map>
+#include <new>
+#include <stdexcept>
+
+namespace mlir{
+
+class MemoryManager {
+public:
+  virtual ~MemoryManager() = default;
+  virtual uint64_t allocate(size_t size) = 0;
+  virtual void free(uint64_t addr) = 0;
+  virtual void read(uint64_t addr, void *dst, size_t size) = 0;
+  virtual void write(uint64_t addr, const void *src, size_t size) = 0;
+};
+
+/// TODO: Move to another file maybe?
+/// A naive memory manager that stores all allocations in one contiguous buffer.
+/// For each allocation, it:
+///  - Returns a 64-bit "address" (offset into the buffer).
+///  - Performs simple bounds checking on read/write.
+class SimpleMemoryManager : public MemoryManager {
+public:
+  explicit SimpleMemoryManager(size_t initialSize = 1024 * 1024)
+      : nextFreeAddress(0) {
+    // Pre-allocate our contiguous memory space
+    Mem.resize(initialSize, 0);
+  }
+
+  /// Allocate 'size' bytes. We return an offset (uint64_t) into our single buffer.
+  /// Throws std::bad_alloc if we can’t fit the allocation.
+  uint64_t allocate(size_t size) override {
+    // Check if we have room in 'mem'
+    if (nextFreeAddress + size > Mem.size())
+      throw std::bad_alloc();
+
+    uint64_t addr = nextFreeAddress;
+    nextFreeAddress += size;
+
+    Allocation allocInfo;
+    allocInfo.size = size;
+    allocations[addr] = allocInfo;
+
+    return addr;
+  }
+
+  /// Free is a no-op in this naive implementation, but we do erase the allocation
+  /// from our map to prevent bounds checking from succeeding if a region is freed.
+  void free(uint64_t addr) override {
+    auto it = allocations.find(addr);
+    if (it != allocations.end()) {
+      allocations.erase(it);
+    }
+    // TODO: Eventually add support for reusing freed memory.
+  }
+
+  /// Read 'size' bytes from address 'addr' into 'dst'.
+  /// Performs simple bounds checking against our recorded allocations.
+  void read(uint64_t addr, void *dst, size_t size) override {
+    auto [allocStart, allocInfo] = findAllocation(addr);
+    // Ensure the entire read fits within [allocStart, allocStart + allocSize)
+    if (addr + size > allocStart + allocInfo.size)
+      throw std::runtime_error("SimpleMemoryManager: read out of bounds");
+
+    std::memcpy(dst, &Mem[addr], size);
+  }
+
+  /// Write 'size' bytes from 'src' into address 'addr'.
+  /// Performs simple bounds checking.
+  void write(uint64_t addr, const void *src, size_t size) override {
+    auto [allocStart, allocInfo] = findAllocation(addr);
+    // Ensure the entire write fits within [allocStart, allocStart + allocSize)
+    if (addr + size > allocStart + allocInfo.size)
+      throw std::runtime_error("SimpleMemoryManager: write out of bounds");
+
+    std::memcpy(&Mem[addr], src, size);
+  }
+
+private:
+  /// A struct to track basic allocation metadata.
+  /// TODO: Add alignment, original request, etc.
+  struct Allocation {
+    size_t size;
+  };
+
+  /// Lookup which allocation covers a given address 'addr'.
+  /// We do a lower_bound or predecessor search to find the earliest allocation
+  /// that starts before (or at) 'addr'.
+  std::pair<uint64_t, Allocation> findAllocation(uint64_t addr) {
+    // Upper bound returns the first iterator greater than 'addr'.
+    auto it = allocations.upper_bound(addr);
+    // If 'it' is not the first in the map, step back one to see if that
+    // allocation covers 'addr'.
+    if (it != allocations.begin()) {
+      --it;
+      uint64_t allocStart = it->first;
+      const Allocation &info = it->second;
+      if (addr >= allocStart && addr < (allocStart + info.size)) {
+        return {allocStart, info};
+      }
+    }
+    throw std::runtime_error("SimpleMemoryManager: address not in any allocation");
+  }
+
+  // A single contiguous buffer
+  std::vector<char> Mem;
+
+  // The offset for the next allocation.
+  uint64_t nextFreeAddress;
+
+  // Map from "address" (offset) -> Allocation metadata
+  std::map<uint64_t, Allocation> allocations;
+};
+}
+
+// TODO: Eventaully add something for, say, a DRAMSimMemoryManager or other popular memory systems.
+
+#endif // MLIR_INTERPRETER_MEMORYMANAGER_H

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -71,3 +71,4 @@ mlir_tablegen(InterpreterOpInterface.cpp.inc -gen-op-interface-defs)
 add_public_tablegen_target(MLIRInterpreterOpInterfaceIncGen)
 
 add_dependencies(MLIRInterpreterLib MLIRInterpreterOpInterfaceIncGen)
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,6 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Set CMake policies
+cmake_policy(SET CMP0057 NEW)
+cmake_policy(SET CMP0116 NEW)
+
 add_library(MLIRInterpreterLib SHARED
   Interpreter/Interpreter.cpp
   Interpreter/InterpreterOpInterface.cpp
@@ -23,9 +27,10 @@ add_library(MLIRInterpreterLib SHARED
 )
 
 # Include directories for the library
-target_include_directories(MLIRInterpreterLib PRIVATE
-  ${CMAKE_SOURCE_DIR}/include
-  ${CMAKE_BINARY_DIR}/include
+target_include_directories(MLIRInterpreterLib PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 # List of required LLVM components
@@ -40,7 +45,6 @@ set(LLVM_LINK_COMPONENTS
   TransformUtils
   Target
   Remarks
-  # Add other components as needed
 )
 
 # Map LLVM components to library names
@@ -48,7 +52,7 @@ llvm_map_components_to_libnames(LLVM_LIBS ${LLVM_LINK_COMPONENTS})
 
 # Link MLIRInterpreterLib against necessary libraries
 target_link_libraries(MLIRInterpreterLib
-  PRIVATE
+  PUBLIC
   # MLIR libraries
   MLIRIR
   MLIRFuncDialect
@@ -56,7 +60,6 @@ target_link_libraries(MLIRInterpreterLib
   MLIRSupport
   MLIRParser
   MLIRTransforms
-  # Add other MLIR libraries as needed
 
   # LLVM libraries
   ${LLVM_LIBS}
@@ -65,10 +68,64 @@ target_link_libraries(MLIRInterpreterLib
 # TableGen for InterpreterOpInterface
 set(LLVM_TARGET_DEFINITIONS ${CMAKE_SOURCE_DIR}/include/mlir/Interpreter/InterpreterOpInterface.td)
 
-mlir_tablegen(InterpreterOpInterface.h.inc -gen-op-interface-decls)
-mlir_tablegen(InterpreterOpInterface.cpp.inc -gen-op-interface-defs)
+# Set the output directory for generated files
+set(OUTPUT_INC_DIR ${CMAKE_BINARY_DIR}/include/mlir/Interpreter)
+file(MAKE_DIRECTORY ${OUTPUT_INC_DIR})
 
-add_public_tablegen_target(MLIRInterpreterOpInterfaceIncGen)
+# Generate the header file
+add_custom_command(
+  OUTPUT ${OUTPUT_INC_DIR}/InterpreterOpInterface.h.inc
+  COMMAND mlir-tblgen -gen-op-interface-decls
+          -I ${CMAKE_SOURCE_DIR}/include
+          -I ${LLVM_INCLUDE_DIRS}
+          -I ${MLIR_INCLUDE_DIRS}
+          ${LLVM_TARGET_DEFINITIONS}
+          -o ${OUTPUT_INC_DIR}/InterpreterOpInterface.h.inc
+  DEPENDS ${LLVM_TARGET_DEFINITIONS}
+  COMMENT "Generating InterpreterOpInterface.h.inc"
+)
 
+# Generate the source file
+add_custom_command(
+  OUTPUT ${OUTPUT_INC_DIR}/InterpreterOpInterface.cpp.inc
+  COMMAND mlir-tblgen -gen-op-interface-defs
+          -I ${CMAKE_SOURCE_DIR}/include
+          -I ${LLVM_INCLUDE_DIRS}
+          -I ${MLIR_INCLUDE_DIRS}
+          ${LLVM_TARGET_DEFINITIONS}
+          -o ${OUTPUT_INC_DIR}/InterpreterOpInterface.cpp.inc
+  DEPENDS ${LLVM_TARGET_DEFINITIONS}
+  COMMENT "Generating InterpreterOpInterface.cpp.inc"
+)
+
+# Create a custom target for the generated files
+add_custom_target(MLIRInterpreterOpInterfaceIncGen
+  DEPENDS
+    ${OUTPUT_INC_DIR}/InterpreterOpInterface.h.inc
+    ${OUTPUT_INC_DIR}/InterpreterOpInterface.cpp.inc
+)
+
+# Ensure the generated files are available before building the library
 add_dependencies(MLIRInterpreterLib MLIRInterpreterOpInterfaceIncGen)
 
+# Install the library target
+install(TARGETS MLIRInterpreterLib
+  EXPORT MLITargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+# Install public headers
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+  DESTINATION include
+  FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp" PATTERN "*.td" PATTERN "*.inc"
+)
+
+# Install generated headers
+install(FILES
+  ${OUTPUT_INC_DIR}/InterpreterOpInterface.h.inc
+  ${OUTPUT_INC_DIR}/InterpreterOpInterface.cpp.inc
+  DESTINATION include/mlir/Interpreter
+)

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -25,6 +25,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/Interpreter/InterpreterOpInterface.h"
+#include "mlir/Interpreter/MemoryManager.h"
 #include "mlir/Support/DebugStringHelper.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -48,8 +49,17 @@ char *EvalValue::getRawData() { return impl->getRawData(); }
 
 const char *EvalValue::getRawData() const { return impl->getRawData(); }
 
-Interpreter::Interpreter(MLIRContext &context, bool enableStackTraceOnError)
-    : context(&context), enableStackTraceOnError(enableStackTraceOnError) {}
+Interpreter::Interpreter(MLIRContext &context,
+                         bool enableStackTraceOnError,
+                         std::unique_ptr<MemoryManager> memMgr)
+    : context(&context),
+      enableStackTraceOnError(enableStackTraceOnError),
+      MemManager(std::move(memMgr)) {
+  // If the user didn't supply a MemoryManager, use a simple default.
+  if (!MemManager) {
+    MemManager = std::make_unique<SimpleMemoryManager>(1024 * 1024 * 1024 - 1);
+  }
+}
 
 EvalResult Interpreter::execute(StringRef entryFuncName,
                                 ArrayRef<EvalValue> arguments) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(mli MLI.cpp)
 
 target_include_directories(mli PRIVATE
   ${CMAKE_SOURCE_DIR}/include
-  ${CMAKE_BINARY_DIR}/include
+  ${CMAKE_BINARY_DIR}/include  # Include generated headers
 )
 
 # List of required LLVM components
@@ -38,11 +38,10 @@ set(LLVM_LINK_COMPONENTS
 # Map LLVM components to library names
 llvm_map_components_to_libnames(LLVM_LIBS ${LLVM_LINK_COMPONENTS})
 
-# Link interpreter-driver against necessary libraries
+# Link mli executable against necessary libraries
 target_link_libraries(mli
   PRIVATE
   MLIRInterpreterLib
-  # MLIR libraries
   MLIRIR
   MLIRFuncDialect
   MLIRLLVMDialect
@@ -50,7 +49,13 @@ target_link_libraries(mli
   MLIRParser
   MLIRTransforms
   LLVMSupport
-
-  # LLVM libraries
   ${LLVM_LIBS}
+)
+
+# Ensure mli depends on the generated headers
+add_dependencies(mli MLIRInterpreterOpInterfaceIncGen)
+
+# Install the executable
+install(TARGETS mli
+  RUNTIME DESTINATION bin
 )


### PR DESCRIPTION
This PR adds a very basic backing store to `MLI` and creates an API for others to eventually build support for other external memory libraries (ie. DRAMSim). 

At this point no other implmentations exist with the exception of the basic character array version built in (SimpleMemoryManager). 

This will allow the future development of dialects with operations such as `llvm.store` and `llvm.load` 

Right now a `MemoryManger` needs to implement support for: 

1. `write` 
2. `read` 
3. `allocate` 
4. `free` 

I could see `allocate` and `free` being made optional but for now its included as mandatory